### PR TITLE
[FEAT] 에러, 404, 로딩 화면 추가 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import DiaryLibrary from './pages/diary-library';
 import MoodCalendar from './pages/calendar';
 import NotFoundPage from './pages/not-found';
 import ErrorPage from './pages/error';
+import LoadingPage from './pages/loading';
 
 function Router() {
   return (
@@ -39,6 +40,7 @@ function Router() {
       <Route path='/diary/write' component={DiaryWriting} />
       <Route path='/diary-preview' component={DiaryPreview} />
       <Route path='/diary-library' component={DiaryLibrary} />
+      <Route path='/loading' component={LoadingPage} />
       <Route path='/error' component={ErrorPage} />
       <Route component={NotFoundPage} />
     </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import DiaryPreview from './pages/diary-preview';
 import DiaryLibrary from './pages/diary-library';
 
 import MoodCalendar from './pages/calendar';
+import NotFoundPage from './pages/not-found';
+import ErrorPage from './pages/error';
 
 function Router() {
   return (
@@ -34,10 +36,11 @@ function Router() {
       <Route path='/start-page' component={StartPage} />
       <Route path='/time-capsule' component={TimeCapsulePage} />
       <Route path='/calendar' component={MoodCalendar} />
-      {/*<Route component={NotFound} />*/}
       <Route path='/diary/write' component={DiaryWriting} />
       <Route path='/diary-preview' component={DiaryPreview} />
       <Route path='/diary-library' component={DiaryLibrary} />
+      <Route path='/error' component={ErrorPage} />
+      <Route component={NotFoundPage} />
     </Switch>
   );
 }

--- a/src/assets/emojiPool.ts
+++ b/src/assets/emojiPool.ts
@@ -1,0 +1,21 @@
+// 이모지 후보 풀: 원하는 표정들로 바꿔도 됩니다.
+// 아래 배열 순서/구성만 수정하면 404/ERROR 화면에 바로 반영돼요.
+
+import angry from './img/emotion/angry-emoji.png';
+import anxiety from './img/emotion/anxiety-emoji.png';
+import basic from './img/emotion/basic-emoji.png';
+import expressionless from './img/emotion/expressionless-emoji.png';
+import happiness from './img/emotion/happiness-emoji.png';
+import joy from './img/emotion/joy-emoji.png';
+import sadness from './img/emotion/sadness-emoji.png';
+
+export const emojiPool: string[] = [
+  angry,
+  anxiety,
+  basic,
+  expressionless,
+  happiness,
+  joy,
+  sadness,
+];
+

--- a/src/components/common/EmojiPixel404.tsx
+++ b/src/components/common/EmojiPixel404.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+
+export interface EmojiPixel404Props {
+  images: string[];
+  tile?: number; // px within viewBox units
+  gap?: number; // px between tiles
+  rotate?: number; // max random rotation in degrees
+  matrix?: number[][]; // optional custom bitmap: 1 = emoji, 0 = empty
+  spaceCols?: number; // digits spacing in columns when matrix not provided
+}
+
+/*
+ * 픽셀아트 비트맵 (1=이모지, 0=비움)
+ */
+export const DIGIT_4: number[][] = [
+  [1, 0, 1, 0, 0],
+  [1, 0, 1, 0, 0],
+  [1, 1, 1, 1, 1],
+  [0, 0, 1, 0, 0],
+  [0, 0, 1, 0, 0],
+  [0, 0, 1, 0, 0],
+  [0, 0, 1, 0, 0],
+];
+
+export const DIGIT_0: number[][] = [
+  [0, 1, 1, 1, 0],
+  [1, 0, 0, 0, 1],
+  [1, 0, 0, 0, 1],
+  [1, 0, 0, 0, 1],
+  [1, 0, 0, 0, 1],
+  [1, 0, 0, 0, 1],
+  [0, 1, 1, 1, 0],
+];
+
+function makeDigit4(height = 11, width = 9): number[][] {
+  const rows: number[][] = [];
+  for (let r = 0; r < height; r++) {
+    const row = new Array(width).fill(0);
+    if (r <= Math.floor(height * 0.6)) row[0] = 1; // left vertical up to crossbar
+    row[width - 1] = 1; // right vertical
+    if (r === Math.floor(height * 0.6)) for (let c = 0; c < width; c++) row[c] = 1; // crossbar
+    rows.push(row);
+  }
+  return rows;
+}
+
+function makeDigit0(height = 11, width = 9): number[][] {
+  const rows: number[][] = [];
+  for (let r = 0; r < height; r++) {
+    const row = new Array(width).fill(0);
+    if (r === 0 || r === height - 1) {
+      for (let c = 0; c < width; c++) row[c] = 1;
+    } else {
+      row[0] = 1;
+      row[width - 1] = 1;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+function joinWithSpacing(a: number[][], b: number[][], spacingCols = 3): number[][] {
+  const height = Math.max(a.length, b.length);
+  const pad = (m: number[][]) =>
+    Array.from({ length: height }, (_, r) => (m[r] ? m[r] : new Array(m[0].length).fill(0)));
+  const A = pad(a);
+  const B = pad(b);
+  const space = new Array(spacingCols).fill(0);
+  return A.map((row, r) => [...row, ...space, ...B[r]]);
+}
+
+export default function EmojiPixel404({ images, tile = 26, gap = 4, rotate = 0, matrix: custom, spaceCols = 2 }: EmojiPixel404Props) {
+  const matrix = useMemo(() => {
+    if (custom && custom.length && custom[0]?.length) return custom;
+    const d4 = DIGIT_4;
+    const d0 = DIGIT_0;
+    const left = joinWithSpacing(d4, d0, spaceCols); // 숫자 사이 공백
+    const all = joinWithSpacing(left, d4, spaceCols);
+    return all;
+  }, [custom, spaceCols]);
+
+  const rows = matrix.length;
+  const cols = matrix[0]?.length ?? 0;
+  const W = cols * tile + (cols - 1) * gap;
+  const H = rows * tile + (rows - 1) * gap;
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`} role="img" aria-label="404 Pixel Emoji" className="mx-auto">
+      {matrix.map((row, r) =>
+        row.map((v, c) => {
+          if (!v) return null;
+          const x = c * (tile + gap);
+          const y = r * (tile + gap);
+          const src = images[(r * cols + c) % images.length];
+          const rot = rotate ? (((r * 13 + c * 29) % (rotate * 2 + 1)) - rotate) : 0;
+          return (
+            <g key={`${r}-${c}`} transform={`translate(${x}, ${y}) rotate(${rot}, ${tile / 2}, ${tile / 2})`}>
+              <image href={src} xlinkHref={src as any} x={0} y={0} width={tile} height={tile} preserveAspectRatio="xMidYMid slice" />
+            </g>
+          );
+        })
+      )}
+    </svg>
+  );
+}

--- a/src/components/common/EmojiPixel404.tsx
+++ b/src/components/common/EmojiPixel404.tsx
@@ -7,6 +7,7 @@ export interface EmojiPixel404Props {
   rotate?: number; // max random rotation in degrees
   matrix?: number[][]; // optional custom bitmap: 1 = emoji, 0 = empty
   spaceCols?: number; // digits spacing in columns when matrix not provided
+  ariaLabel?: string; // custom aria-label for accessibility
 }
 
 /*
@@ -69,7 +70,7 @@ function joinWithSpacing(a: number[][], b: number[][], spacingCols = 3): number[
   return A.map((row, r) => [...row, ...space, ...B[r]]);
 }
 
-export default function EmojiPixel404({ images, tile = 26, gap = 4, rotate = 0, matrix: custom, spaceCols = 2 }: EmojiPixel404Props) {
+export default function EmojiPixel404({ images, tile = 26, gap = 4, rotate = 0, matrix: custom, spaceCols = 2, ariaLabel }: EmojiPixel404Props) {
   const matrix = useMemo(() => {
     if (custom && custom.length && custom[0]?.length) return custom;
     const d4 = DIGIT_4;
@@ -79,13 +80,26 @@ export default function EmojiPixel404({ images, tile = 26, gap = 4, rotate = 0, 
     return all;
   }, [custom, spaceCols]);
 
+  // Early return if no images provided
+  if (!images || images.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">No emoji images available</p>
+      </div>
+    );
+  }
+
   const rows = matrix.length;
   const cols = matrix[0]?.length ?? 0;
   const W = cols * tile + (cols - 1) * gap;
   const H = rows * tile + (rows - 1) * gap;
 
+  // Generate dynamic aria-label based on context
+  const defaultAriaLabel = custom ? "Pixel art display with emojis" : "404 error displayed as pixel art with emojis";
+  const finalAriaLabel = ariaLabel || defaultAriaLabel;
+
   return (
-    <svg width="100%" viewBox={`0 0 ${W} ${H}`} role="img" aria-label="404 Pixel Emoji" className="mx-auto">
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`} role="img" aria-label={finalAriaLabel} className="mx-auto">
       {matrix.map((row, r) =>
         row.map((v, c) => {
           if (!v) return null;

--- a/src/components/common/EmojiText.tsx
+++ b/src/components/common/EmojiText.tsx
@@ -25,9 +25,18 @@ export default function EmojiText({
 }: EmojiTextProps) {
   const [placed, setPlaced] = useState<Placed[]>([]);
 
+  // Generate unique clipPath ID to prevent conflicts
+  const clipPathId = useMemo(() => `roundedEmojiTile-${Math.random().toString(36).substr(2, 9)}`, []);
+
   const distMin = useMemo(() => (minDistance ?? tile * 0.82), [minDistance, tile]);
 
   useEffect(() => {
+    // Early return if no images provided
+    if (!images || images.length === 0) {
+      setPlaced([]);
+      return;
+    }
+
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
@@ -112,16 +121,25 @@ export default function EmojiText({
     setPlaced(tiles);
   }, [text, images, width, height, step, outline, distMin]);
 
+  // Early return if no images provided
+  if (!images || images.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">No emoji images available</p>
+      </div>
+    );
+  }
+
   return (
     <svg width="100%" viewBox={`0 0 ${width} ${height}`} role="img" aria-label={text} className="mx-auto">
       <defs>
-        <clipPath id="roundedEmojiTile" clipPathUnits="userSpaceOnUse">
+        <clipPath id={clipPathId} clipPathUnits="userSpaceOnUse">
           <rect x={-tile / 2} y={-tile / 2} width={tile} height={tile} rx={6} ry={6} />
         </clipPath>
       </defs>
       <g>
         {placed.map((p, i) => (
-          <g key={i} transform={`translate(${p.x}, ${p.y}) rotate(${p.a})`} clipPath="url(#roundedEmojiTile)">
+          <g key={i} transform={`translate(${p.x}, ${p.y}) rotate(${p.a})`} clipPath={`url(#${clipPathId})`}>
             <image href={p.src} x={-tile / 2} y={-tile / 2} width={tile} height={tile} preserveAspectRatio="xMidYMid slice" />
           </g>
         ))}

--- a/src/components/common/EmojiText.tsx
+++ b/src/components/common/EmojiText.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+type Placed = { x: number; y: number; a: number; src: string };
+
+export interface EmojiTextProps {
+  text: string;
+  images: string[];
+  width?: number;
+  height?: number;
+  tile?: number; // emoji tile size (px in viewBox units)
+  step?: number; // grid sampling step (larger -> sparser)
+  outline?: boolean; // sample only the outline instead of fill
+  minDistance?: number; // minimal distance between tiles for regularity
+}
+
+export default function EmojiText({
+  text,
+  images,
+  width = 420,
+  height = 220,
+  tile = 24,
+  step = 24,
+  outline = true,
+  minDistance,
+}: EmojiTextProps) {
+  const [placed, setPlaced] = useState<Placed[]>([]);
+
+  const distMin = useMemo(() => (minDistance ?? tile * 0.82), [minDistance, tile]);
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Fit bold text to width
+    let fontSize = height * 0.86;
+    const family = "'Inter', 'Noto Sans KR', system-ui, -apple-system, Segoe UI, Roboto, Arial, Helvetica, sans-serif";
+    for (let i = 0; i < 4; i++) {
+      ctx.clearRect(0, 0, width, height);
+      ctx.font = `900 ${fontSize}px ${family}`;
+      const mw = ctx.measureText(text).width;
+      const target = width * 0.9;
+      if (mw > target) fontSize *= target / mw; else break;
+    }
+
+    ctx.font = `900 ${fontSize}px ${family}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#000';
+    ctx.fillText(text, width / 2, height * 0.58);
+
+    const img = ctx.getImageData(0, 0, width, height);
+    const data = img.data;
+    const alphaAt = (x: number, y: number) => data[(y * width + x) * 4 + 3] | 0;
+
+    const points: { x: number; y: number }[] = [];
+
+    for (let y = Math.floor(step / 2); y < height; y += step) {
+      for (let x = Math.floor(step / 2); x < width; x += step) {
+        const a = alphaAt(x, y);
+        if (a < 30) continue;
+        if (outline) {
+          // include only if near edge: has a neighbor outside glyph
+          let edge = false;
+          for (let oy = -1; oy <= 1 && !edge; oy++) {
+            for (let ox = -1; ox <= 1 && !edge; ox++) {
+              if (ox === 0 && oy === 0) continue;
+              const nx = Math.max(0, Math.min(width - 1, x + ox));
+              const ny = Math.max(0, Math.min(height - 1, y + oy));
+              if (alphaAt(nx, ny) < 30) edge = true;
+            }
+          }
+          if (!edge) continue;
+        }
+        points.push({ x, y });
+      }
+    }
+
+    // Greedy thinning to enforce minimum distance between tiles
+    const selected: { x: number; y: number }[] = [];
+    const dist2 = (a: { x: number; y: number }, b: { x: number; y: number }) => {
+      const dx = a.x - b.x;
+      const dy = a.y - b.y;
+      return dx * dx + dy * dy;
+    };
+    const minD2 = distMin * distMin;
+    for (let i = 0; i < points.length; i++) {
+      const p = points[i];
+      let ok = true;
+      for (let j = 0; j < selected.length; j++) {
+        if (dist2(p, selected[j]) < minD2) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) selected.push(p);
+    }
+
+    // Place tiles with small jitter/rotation for organic feel
+    const tiles: Placed[] = [];
+    for (let i = 0; i < selected.length; i++) {
+      const p = selected[i];
+      const src = images[i % images.length];
+      const jx = ((p.x * 17 + p.y * 23) % 5) - 2;
+      const jy = ((p.x * 13 + p.y * 19) % 5) - 2;
+      const ang = (((p.x * 29 + p.y * 31) % 5) - 2) * 1.2;
+      tiles.push({ x: p.x + jx * 0.25, y: p.y + jy * 0.25, a: ang, src });
+    }
+
+    setPlaced(tiles);
+  }, [text, images, width, height, step, outline, distMin]);
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${width} ${height}`} role="img" aria-label={text} className="mx-auto">
+      <defs>
+        <clipPath id="roundedEmojiTile" clipPathUnits="userSpaceOnUse">
+          <rect x={-tile / 2} y={-tile / 2} width={tile} height={tile} rx={6} ry={6} />
+        </clipPath>
+      </defs>
+      <g>
+        {placed.map((p, i) => (
+          <g key={i} transform={`translate(${p.x}, ${p.y}) rotate(${p.a})`} clipPath="url(#roundedEmojiTile)">
+            <image href={p.src} x={-tile / 2} y={-tile / 2} width={tile} height={tile} preserveAspectRatio="xMidYMid slice" />
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}
+

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -106,7 +106,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({
         </div>
       </div>
 
-      <style jsx>{`
+      <style>{`
         @keyframes gentlePulse {
           0% { transform: scale(1); }
           100% { transform: scale(1.03); }

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { emojiPool } from '../../assets/emojiPool';
+import gradientBg from '../../assets/img/gradientbackground.png';
+
+const icons = emojiPool;
+
+interface LoadingScreenProps {
+  message?: string;
+  submessage?: string;
+}
+
+const LoadingScreen: React.FC<LoadingScreenProps> = ({ 
+  message = "잠시만 기다려주세요",
+  submessage = "감정을 불러오고 있어요"
+}) => {
+  const [currentEmoji, setCurrentEmoji] = useState(0);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIsVisible(false);
+      setTimeout(() => {
+        setCurrentEmoji((prev) => (prev + 1) % icons.length);
+        setIsVisible(true);
+      }, 200);
+    }, 800);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="w-full h-full relative flex flex-col items-center justify-center p-6 text-center bg-white overflow-hidden">
+      {/* background */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `url(${gradientBg})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          opacity: 0.35,
+          filter: 'saturate(110%)',
+        }}
+      />
+
+      <div className="relative max-w-[440px] w-full">
+        <header className="mb-8">
+          <h1 className="text-xl font-bold">{message}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{submessage}</p>
+        </header>
+
+        {/* Large animated emoji */}
+        <div className="mb-12 flex items-center justify-center">
+          <div
+            className={`transition-all duration-300 ease-out ${
+              isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-90'
+            }`}
+            style={{
+              transform: isVisible ? 'scale(1) rotate(0deg)' : 'scale(0.9) rotate(-5deg)',
+            }}
+          >
+            <img
+              src={icons[currentEmoji]}
+              alt="Loading emoji"
+              className="w-32 h-32 rounded-2xl"
+              style={{
+                filter: 'drop-shadow(0 8px 24px rgba(0,0,0,0.12))',
+                animation: isVisible ? 'gentlePulse 2s ease-in-out infinite alternate' : 'none',
+                imageRendering: 'crisp-edges',
+                WebkitImageRendering: 'crisp-edges',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Simple loading text */}
+        <div className="mb-8">
+          <h2 className="text-2xl font-bold text-gray-800 tracking-wider">LOADING</h2>
+        </div>
+
+        {/* Loading dots */}
+        <div className="mt-8 flex items-center justify-center space-x-2">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="w-2 h-2 bg-primary rounded-full animate-bounce"
+              style={{
+                animationDelay: `${i * 0.2}s`,
+                animationDuration: '1.4s',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes gentlePulse {
+          0% { transform: scale(1); }
+          100% { transform: scale(1.03); }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default LoadingScreen;

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { emojiPool } from '../../assets/emojiPool';
 import gradientBg from '../../assets/img/gradientbackground.png';
 
@@ -9,23 +9,36 @@ interface LoadingScreenProps {
   submessage?: string;
 }
 
-const LoadingScreen: React.FC<LoadingScreenProps> = ({ 
+const LoadingScreen: React.FC<LoadingScreenProps> = ({
   message = "잠시만 기다려주세요",
   submessage = "감정을 불러오고 있어요"
 }) => {
   const [currentEmoji, setCurrentEmoji] = useState(0);
   const [isVisible, setIsVisible] = useState(true);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    if (icons.length === 0) return;
+
+    intervalRef.current = setInterval(() => {
       setIsVisible(false);
-      setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         setCurrentEmoji((prev) => (prev + 1) % icons.length);
         setIsVisible(true);
       }, 200);
     }, 800);
 
-    return () => clearInterval(interval);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
   }, []);
 
   return (

--- a/src/pages/emotion-report.tsx
+++ b/src/pages/emotion-report.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'wouter';
 import { ArrowLeft, Download, TrendingUp, Heart } from 'lucide-react';
+import LoadingScreen from '../components/common/LoadingScreen';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { useToast } from '../hooks/use-toast';
@@ -174,16 +175,7 @@ export default function EmotionReportPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className='gradient-mypage flex flex-col relative h-full'>
-        <div className='flex items-center justify-center h-full'>
-          <div className='text-center'>
-            <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4'></div>
-            <p className='text-gray-400'>감정 리포트를 분석하고 있습니다...</p>
-          </div>
-        </div>
-      </div>
-    );
+    return <LoadingScreen message="감정 리포트를 분석하고 있습니다" submessage="AI가 대화 내용을 분석중이에요" />;
   }
 
   if (!emotionReport) {

--- a/src/pages/error.tsx
+++ b/src/pages/error.tsx
@@ -87,7 +87,14 @@ const ErrorPage: React.FC = () => {
 
         <div className="flex justify-center">
           {/* 화면 폭이 좁으므로 작은 타일/간격 */}
-          <EmojiPixel404 images={icons} matrix={matrix} tile={14} gap={2} rotate={1} />
+          <EmojiPixel404
+            images={icons}
+            matrix={matrix}
+            tile={14}
+            gap={2}
+            rotate={1}
+            ariaLabel="Error message displayed as pixel art with emojis"
+          />
         </div>
 
         <div className="mt-10 flex items-center justify-center gap-3">

--- a/src/pages/error.tsx
+++ b/src/pages/error.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo } from 'react';
+import { Link } from 'wouter';
+import { Button } from '../components/ui/button';
+import EmojiPixel404 from '../components/common/EmojiPixel404';
+
+import { emojiPool } from '../assets/emojiPool';
+import gradientBg from '../assets/img/gradientbackground.png';
+
+/** 이모지 후보 풀: 원하는 표정들로 바꿔도 됩니다 */
+const icons = emojiPool;
+
+// 5x7 픽셀 아트 대문자 비트맵
+const LETTERS: Record<string, number[][]> = {
+  E: [
+    [1,1,1,1,1],
+    [1,0,0,0,0],
+    [1,1,1,1,0],
+    [1,0,0,0,0],
+    [1,0,0,0,0],
+    [1,0,0,0,0],
+    [1,1,1,1,1],
+  ],
+  R: [
+    [1,1,1,1,0],
+    [1,0,0,0,1],
+    [1,0,0,0,1],
+    [1,1,1,1,0],
+    [1,0,1,0,0],
+    [1,0,0,1,0],
+    [1,0,0,0,1],
+  ],
+  O: [
+    [0,1,1,1,0],
+    [1,0,0,0,1],
+    [1,0,0,0,1],
+    [1,0,0,0,1],
+    [1,0,0,0,1],
+    [1,0,0,0,1],
+    [0,1,1,1,0],
+  ],
+};
+
+function joinCols(a: number[][], b: number[][], gapCols: number) {
+  const height = Math.max(a.length, b.length);
+  const pad = (m: number[][]) => Array.from({ length: height }, (_, i) => m[i] ?? new Array(m[0].length).fill(0));
+  const A = pad(a), B = pad(b);
+  const gap = new Array(gapCols).fill(0);
+  return A.map((row, i) => [...row, ...gap, ...B[i]]);
+}
+
+function useErrorMatrix() {
+  return useMemo(() => {
+    const gap = 1; // 문자 사이 1열 공백
+    const E = LETTERS.E;
+    const R = LETTERS.R;
+    const O = LETTERS.O;
+    let m = joinCols(E, R, gap);
+    m = joinCols(m, R, gap);
+    m = joinCols(m, O, gap);
+    m = joinCols(m, R, gap);
+    return m;
+  }, []);
+}
+
+const ErrorPage: React.FC = () => {
+  const matrix = useErrorMatrix();
+  return (
+    <div className="w-full h-full relative flex flex-col items-center justify-center p-6 text-center bg-white overflow-hidden">
+      {/* background */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `url(${gradientBg})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          opacity: 0.35,
+          filter: 'saturate(110%)',
+        }}
+      />
+
+      <div className="relative max-w-[480px] w-full">
+        <header className="mb-8">
+          <h1 className="text-xl font-bold">문제가 발생했어요</h1>
+          <p className="mt-1 text-sm text-muted-foreground">일시적인 오류예요. 잠시 후 다시 시도해 주세요.</p>
+        </header>
+
+        <div className="flex justify-center">
+          {/* 화면 폭이 좁으므로 작은 타일/간격 */}
+          <EmojiPixel404 images={icons} matrix={matrix} tile={14} gap={2} rotate={1} />
+        </div>
+
+        <div className="mt-10 flex items-center justify-center gap-3">
+          <Button onClick={() => window.location.reload()}>다시 시도</Button>
+          <Button variant="secondary" asChild>
+            <Link href="/">홈으로</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/pages/loading.tsx
+++ b/src/pages/loading.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'wouter';
+import { emojiPool } from '../assets/emojiPool';
+import gradientBg from '../assets/img/gradientbackground.png';
+
+const icons = emojiPool;
+
+const LoadingPage: React.FC = () => {
+  const [currentEmoji, setCurrentEmoji] = useState(0);
+  const [isVisible, setIsVisible] = useState(true);
+  const [, navigate] = useLocation();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIsVisible(false);
+      setTimeout(() => {
+        setCurrentEmoji((prev) => (prev + 1) % icons.length);
+        setIsVisible(true);
+      }, 200);
+    }, 800);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  // 로딩 완료 후 리다이렉트 처리
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const redirectPage = urlParams.get('redirect');
+    
+    const loadingTimer = setTimeout(() => {
+      if (redirectPage) {
+        navigate(`/${redirectPage}`);
+      } else {
+        // 기본적으로 홈으로 이동
+        navigate('/');
+      }
+    }, 3000); // 3초 로딩
+
+    return () => clearTimeout(loadingTimer);
+  }, [navigate]);
+
+  return (
+    <div className="w-full h-full relative flex flex-col items-center justify-center p-6 text-center bg-white overflow-hidden">
+      {/* background */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `url(${gradientBg})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          opacity: 0.35,
+          filter: 'saturate(110%)',
+        }}
+      />
+
+      <div className="relative max-w-[440px] w-full">
+        <header className="mb-8">
+          <h1 className="text-xl font-bold">잠시만 기다려주세요</h1>
+          <p className="mt-2 text-sm text-muted-foreground">감정을 불러오고 있어요</p>
+        </header>
+
+        {/* Large animated emoji */}
+        <div className="mb-12 flex items-center justify-center">
+          <div
+            className={`transition-all duration-300 ease-out ${
+              isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-90'
+            }`}
+            style={{
+              transform: isVisible ? 'scale(1) rotate(0deg)' : 'scale(0.9) rotate(-5deg)',
+            }}
+          >
+            <img
+              src={icons[currentEmoji]}
+              alt="Loading emoji"
+              className="w-32 h-32 rounded-2xl"
+              style={{
+                filter: 'drop-shadow(0 8px 24px rgba(0,0,0,0.12))',
+                animation: isVisible ? 'gentlePulse 2s ease-in-out infinite alternate' : 'none',
+                imageRendering: 'crisp-edges',
+                WebkitImageRendering: 'crisp-edges',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Simple loading text */}
+        <div className="mb-8">
+          <h2 className="text-2xl font-bold text-gray-800 tracking-wider">LOADING</h2>
+        </div>
+
+        {/* Loading dots */}
+        <div className="mt-8 flex items-center justify-center space-x-2">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="w-2 h-2 bg-primary rounded-full animate-bounce"
+              style={{
+                animationDelay: `${i * 0.2}s`,
+                animationDuration: '1.4s',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes gentlePulse {
+          0% { transform: scale(1); }
+          100% { transform: scale(1.03); }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default LoadingPage;

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -45,7 +45,17 @@ const NotFoundPage: React.FC = () => {
           <Button asChild>
             <Link href="/">홈으로</Link>
           </Button>
-          <Button variant="outline" onClick={() => window.history.back()}>
+          <Button
+            variant="outline"
+            onClick={() => {
+              // Fallback to home if history is empty
+              if (window.history.length <= 1) {
+                window.location.href = '/';
+              } else {
+                window.history.back();
+              }
+            }}
+          >
             이전으로
           </Button>
         </div>

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Link } from 'wouter';
+import { Button } from '../components/ui/button';
+import EmojiPixel404 from '../components/common/EmojiPixel404';
+
+import { emojiPool } from '../assets/emojiPool';
+import gradientBg from '../assets/img/gradientbackground.png';
+
+/** 이모지 후보 풀: 원하는 표정들로 바꿔도 됩니다 */
+const icons = emojiPool;
+
+function EmojiText404() {
+  return <EmojiPixel404 images={icons} tile={26} gap={4} rotate={2} spaceCols={1} />;
+}
+
+const NotFoundPage: React.FC = () => {
+  return (
+    <div className="w-full h-full relative flex flex-col items-center justify-center p-6 text-center bg-white overflow-hidden">
+      {/* background image (home.png) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `url(${gradientBg})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          opacity: 0.35,
+          filter: 'saturate(110%)',
+        }}
+      />
+
+      <div className="relative max-w-[480px] w-full">
+        <header className="mb-8">
+          <h1 className="text-xl font-bold">Whoops, that page is gone.</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            찾으시는 페이지가 존재하지 않거나 이동되었어요. (404)
+          </p>
+        </header>
+
+        <div className="flex justify-center">
+          <EmojiText404 />
+        </div>
+
+        <div className="mt-10 flex items-center justify-center gap-3">
+          <Button asChild>
+            <Link href="/">홈으로</Link>
+          </Button>
+          <Button variant="outline" onClick={() => window.history.back()}>
+            이전으로
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/src/pages/voice-chat.tsx
+++ b/src/pages/voice-chat.tsx
@@ -217,8 +217,8 @@ export default function VoiceChat() {
       '대화를 종료하고 감정 리포트를 확인하시겠습니까?'
     );
     if (confirmed) {
-      // 감정 리포트 페이지로 이동
-      navigate('/emotion-report');
+      // 로딩 화면을 거쳐 감정 리포트로 이동
+      navigate('/loading?redirect=emotion-report');
     }
   };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,32 @@
 /// <reference types="vite/client" />
+
+// Type declarations for image imports
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpeg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.gif' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.webp' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
#21 

<!-- ex) #이슈번호 -->

<br><br>

## 📄 Work Description

<!-- 작업 내용을 설명해주세요 -->

## 에러, 404
 src/App.tsx: /error 추가, 404 fallback 유지
  - src/pages/not-found.tsx: 픽셀 아트 404, 간격/정렬/배경 적용    됩니다”
  - src/pages/error.tsx: 픽셀 아트 ERROR, 간격/정렬/배경 적용 

## 로딩 화면 
### 생각한 흐름 
1. 감정 대화 (/voice-chat) → "Finish Chat" 버튼 클릭      
  2. 로딩 화면 (/loading?redirect=emotion-report) → 3초간   
  이모지 애니메이션 표시
  3. 감정 리포트 (/emotion-report) → 자체 로딩도 새로운     
  LoadingScreen 사용
---
  - voice-chat.tsx: 대화 종료 시 로딩 화면을 거쳐 이동하도록
  수정
  - loading.tsx: 쿼리 파라미터를 받아 자동 리다이렉트 기능       
  추가 (3초 후)
  - LoadingScreen.tsx: 재사용 가능한 로딩 컴포넌트 생성
  - emotion-report.tsx: 새로운 LoadingScreen 컴포넌트 사용 

<br><br>

## 📷 Screenshot

<!-- 동영상, 사진, 로그 등 -->
<img width="609" height="570" alt="image" src="https://github.com/user-attachments/assets/70d1c03f-abd3-4efb-b1c6-4fb5ccdac746" />
<img width="594" height="616" alt="image" src="https://github.com/user-attachments/assets/67a49953-e587-45d5-999e-dfb5d2d5b6a6" />
<img width="746" height="554" alt="image" src="https://github.com/user-attachments/assets/0975d1af-f953-4431-9309-26c400979101" />

<br><br>

## 💬 To Reviewers

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 에러 화면, 404 에서 글씨는 전부 픽셀 아트로 하드코딩하여 구현했습니다. 
- react-tsparticles 같은 라이브러리
- 현재 /error는 직접 접근용입니다. 실제 런타임 예외에 자동 대응하려면 Error Boundary를 추가해 렌더 오류 시 /error로 리다이렉트 해야 할 듯 합니다. 
- 일기 작성 완료 후 → 일기 미리보기/라이브러리로 이동 시에도 로딩을 적용해야 할까요..? 
- 로딩 적용에 대해 좀 생각해봐야 할 것 같습니다. + 공부 ) 예를 들어 마이페이지에서 데이터 수정 후 저장 시에도 로딩 띄울수도 있고...

### 아직 미구현 

- 로딩 
- 로딩 타임아웃 시 재시도 옵션 제공
-  오프라인 상태 감지 및 안내
- ErrorBoundary 추가해 렌더 예외 발생 시 자동으로 에러 화면    
  전환
- 애니메이션/입자효과 필요하면 react-tsparticles 도입  검토
- 이모지 교체: src/assets/emojiPool.ts에서 배열만 수정하면 됩

<br><br>

## 🔗 Reference

<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dedicated Loading and Error pages with animated emoji visuals and actions (retry, home).
  - Introduced a 404 Not Found page with decorative pixel-art.
  - Added app routes for /loading and /error, plus a catch-all 404.
  - Implemented reusable EmojiText/EmojiPixel components and a shared emoji pool for rich visuals.

- Refactor
  - Replaced inline loading UI in Emotion Report with a reusable LoadingScreen.
  - Updated voice chat completion to route through the Loading page (with auto-redirect) for smoother transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->