### PR TITLE
[Refactor] 감정일기: emotion diary 페이지 연결 및 플로우 개선 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ function Router() {
       <Route path='/start-page' component={StartPage} />
       <Route path='/time-capsule' component={TimeCapsulePage} />
       <Route path='/calendar' component={MoodCalendar} />
-      <Route path='/diary/write' component={DiaryWriting} />
+      <Route path='/diary-write' component={DiaryWriting} />
       <Route path='/diary-preview' component={DiaryPreview} />
       <Route path='/diary-library' component={DiaryLibrary} />
       <Route path='/loading' component={LoadingPage} />

--- a/src/pages/emotion-report.tsx
+++ b/src/pages/emotion-report.tsx
@@ -307,11 +307,25 @@ export default function EmotionReportPage() {
               </div>
             </Card>
 
-            {/* 하단 저장 버튼 */}
-            <div className='pt-6 pb-8'>
+            {/* 하단 버튼들 */}
+            <div className='pt-6 pb-8 space-y-3'>
+              {/* 일기 작성하기 버튼 */}
+              <Button
+                onClick={() => {
+                  // 감정 리포트 데이터를 일기 작성 페이지로 전달하기 위해 loading 페이지를 거침
+                  navigate('/loading?redirect=diary-write');
+                }}
+                className='w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white py-4 rounded-2xl font-medium shadow-xl transition-all duration-300 flex items-center justify-center space-x-2 border border-blue-500/30'
+              >
+                <Heart className='w-5 h-5' />
+                <span>✏️ 감정 일기 작성하기</span>
+              </Button>
+
+              {/* 감정 리포트 저장 버튼 */}
               <Button
                 onClick={handleSaveReport}
-                className='w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white py-4 rounded-2xl font-medium shadow-xl transition-all duration-300 flex items-center justify-center space-x-2 border border-purple-500/30'
+                variant="outline"
+                className='w-full bg-white/10 hover:bg-white/20 text-gray-400 border-gray-400/30 py-4 rounded-2xl font-medium transition-all duration-300 flex items-center justify-center space-x-2'
               >
                 <Download className='w-5 h-5' />
                 <span>↓ 감정 리포트 저장하기</span>

--- a/src/pages/loading.tsx
+++ b/src/pages/loading.tsx
@@ -13,6 +13,32 @@ const LoadingPage: React.FC = () => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const loadingTimerRef = useRef<NodeJS.Timeout | null>(null);
 
+  // URL에서 redirect 파라미터를 가져와서 메시지 결정
+  const urlParams = new URLSearchParams(window.location.search);
+  const redirectPage = urlParams.get('redirect');
+
+  const getLoadingMessage = () => {
+    switch (redirectPage) {
+      case 'emotion-report':
+        return {
+          message: "감정을 분석하고 있어요",
+          submessage: "AI가 대화 내용을 바탕으로 감정을 분석중이에요"
+        };
+      case 'diary-write':
+        return {
+          message: "일기 작성 준비 중이에요",
+          submessage: "감정 분석 결과를 바탕으로 일기 작성을 도와드릴게요"
+        };
+      default:
+        return {
+          message: "잠시만 기다려주세요",
+          submessage: "감정을 불러오고 있어요"
+        };
+    }
+  };
+
+  const { message, submessage } = getLoadingMessage();
+
   useEffect(() => {
     if (icons.length === 0) return;
 
@@ -89,8 +115,8 @@ const LoadingPage: React.FC = () => {
 
       <div className="relative max-w-[440px] w-full">
         <header className="mb-8">
-          <h1 className="text-xl font-bold">잠시만 기다려주세요</h1>
-          <p className="mt-2 text-sm text-muted-foreground">감정을 불러오고 있어요</p>
+          <h1 className="text-xl font-bold">{message}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{submessage}</p>
         </header>
 
         {/* Large animated emoji */}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number

#27 
<!-- ex) #이슈번호 -->

<br><br>

## 📄 Work Description

 1. src/App.tsx

  수정 내용: 라우팅 경로 통일
 
```
  // 수정 후  
  <Route path='/diary-write' component={DiaryWriting} />
```

  이유: 감정 리포트와 로딩 페이지에서 /diary-write로
  navigate하는데, App.tsx에서는 /diary/write로 되어 있어서  라우팅이 안 됐음

  2. src/pages/emotion-report.tsx

일기 작성 버튼 추가
 
  // 수정 후: 일기 작성 + 저장 버튼 
```
  <div className='pt-6 pb-8 space-y-3'>
    {/* 일기 작성하기 버튼 - 새로 추가 */}
    <Button onClick={() =>
  navigate('/loading?redirect=diary-write')}>
      ✏️ 감정 일기 작성하기
    </Button>
```

  - 일기 작성: 파란색 그라데이션 (primary)
  - 리포트 저장: outline 스타일 (secondary)

  3. src/pages/loading.tsx

 동적 메시지 시스템 추가

기존 로딩화면에 이런 문구 추가했습니다: "감정을 분석하고 있어요", "AI가 대화 내용을 바탕으로 감정을 
  분석중이에요"
      
이참에  하드코딩된 메시지를 동적 메시지로 변경했습니다. 
```
  // 수정 후
  <h1 className="text-xl font-bold">{message}</h1>
  <p className="mt-2 text-sm 
  text-muted-foreground">{submessage}</p>
```
<br><br>

## 📷 Screenshot

<!-- 동영상, 사진, 로그 등 -->


<br><br>

## 💬 To Reviewers

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
플로우 확인후, 코드까지 확인해서 코멘트 달아주세요. 

1. 음성 대화 → "Finish Chat" 버튼 클릭
2. 로딩 화면 → "감정을 분석하고 있어요" 메시지
3. 감정 리포트 → "감정 일기 작성하기" 버튼 클릭
4. 로딩 화면 → "일기 작성 준비 중이에요" 메시지
5. 일기 작성 페이지 → 화면 최종 렌더링

참고로 전에 말한 저장 버튼 상단에 추가하는 건 아직 고민이 필요하여 구현하지 않았습니다. 지금처럼 버튼이 중첩되는게 안 예뻐서 상단으로 옮기기는 해야 할 것 같아요. 

그리고, 소영님께: 일기 처음에는 자동 작성이잖아요, 이거 아무 더미 데이터 넣어서 보여주긴 해야 할 거 같아요. 백엔드 연결하면서 AI 작성 메세지를 자동으로 작성되게끔 페이지 조정을 해야 하니, 자동작성 추가 후  test 부탁드립니다. 
<br><br>

## 🔗 Reference

<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>
