### PR TITLE
feat: 다이어리, 캘린더 백엔드 연결

### DIFF
--- a/src/pages/diary-preview.tsx
+++ b/src/pages/diary-preview.tsx
@@ -156,15 +156,21 @@ export default function DiaryPreview() {
     const item = items[idx];
     if (!item) return;
 
-    // 먼저 로컬 상태 업데이트 (낙관적 업데이트)
+    // 낙관적 업데이트
     setItems((prev) => prev.map((it, i) => i === idx ? { ...it, bookmarked: !it.bookmarked } : it));
 
     try {
-      await diaryService.toggleBookmark(item.id, item.bookmarked || false);
+      const updated = await diaryService.toggleBookmark(item.id);
+      // 서버 응답으로 확정
+      setItems((prev) => prev.map((it, i) => i === idx ? { ...it, bookmarked: updated.scraped } : it));
     } catch (error) {
       // 실패 시 원래 상태로 복원
-      setItems((prev) => prev.map((it, i) => i === idx ? { ...it, bookmarked: !it.bookmarked } : it));
-      console.error('Bookmark toggle failed:', error);
+      setItems((prev) => prev.map((it, i) => i === idx ? { ...it, bookmarked: item.bookmarked } : it));
+      toast({
+        title: '북마크 실패',
+        description: error instanceof Error ? error.message : '북마크 변경에 실패했습니다.',
+        variant: 'destructive',
+      });
     }
   };
 

--- a/src/pages/diary-write.tsx
+++ b/src/pages/diary-write.tsx
@@ -5,6 +5,7 @@ import { useToast } from "../hooks/use-toast";
 import { useLocation } from "wouter";
 import { useSidebar } from "../components/sidebar/SidebarContext";
 import { CloudSun, CloudRain, Snowflake, Cloud, Sun } from "lucide-react";
+import { diaryService } from "../services/diaryService";
 
 // 이모지 경로
 import angryEmoji from "../assets/img/emotion/angry-emoji.png";
@@ -58,9 +59,25 @@ export default function DiaryWriting() {
     });
   };
 
-  // 모달 Confirm
-  const confirmFeedback = () => {
-    // (필요하면 서버 전송 코드 추가)
+  // 모달 Confirm — 피드백 API 호출 후 일기 완료 처리
+  const confirmFeedback = async () => {
+    if (!selectedFeedback) return;
+
+    try {
+      // TODO: diaryId는 AI 일기 생성 후 전달받아야 함 (현재는 임시값)
+      // 실제 구현 시 생성된 diaryId를 state/query param으로 전달
+      const diaryId = new URLSearchParams(window.location.search).get('diaryId');
+      if (diaryId) {
+        await diaryService.saveFeedback(diaryId, selectedFeedback);
+      }
+    } catch (error) {
+      toast({
+        title: "피드백 저장 실패",
+        description: error instanceof Error ? error.message : "피드백 저장에 실패했습니다.",
+        variant: "destructive",
+      });
+    }
+
     completeDiary();
     closeFeedbackModal();
   };

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -4,49 +4,54 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080
 // API 타임아웃 설정 (10초)
 const API_TIMEOUT = 10000;
 
-// 백엔드 응답 타입 정의
-export interface CalendarDayDto {
+// 백엔드 응답 타입 정의 (CalendarDateDto)
+export interface CalendarDateDto {
   date: string; // LocalDate -> YYYY-MM-DD
   hasDiary: boolean;
   emotion: string | null;
   isScraped: boolean;
 }
 
-export interface DiaryInfoDto {
+// 백엔드 응답 타입 정의 (DiaryDetailDto)
+export interface DiaryDetailDto {
   diaryId: string;
   title: string;
   content: string;
   emotion: string;
   imageId: string | null;
+  scraped: boolean;
 }
 
-export interface EventDto {
-  id: string;
+// 백엔드 응답 타입 정의 (EventResponseDto)
+export interface EventResponseDto {
+  eventId: string;
   title: string;
-  description: string | null;
   date: string; // LocalDate -> YYYY-MM-DD
   startTime: string | null; // LocalTime -> HH:mm:ss
-  eventType: string; // "USER_CREATED" | "GOOGLE_CALENDAR"
+  description: string | null;
+  createdAt: string; // LocalDateTime -> ISO 8601
 }
 
+// 백엔드 응답 타입 정의 (CalendarResponseDto)
 export interface CalendarResponseDto {
   year: number;
   month: number;
-  days: CalendarDayDto[];
+  dates: CalendarDateDto[];
 }
 
+// 백엔드 응답 타입 정의 (DateDetailResponseDto)
 export interface DateDetailResponseDto {
   date: string;
-  diary: DiaryInfoDto | null;
-  userEvents: EventDto[];
-  googleEvents: EventDto[];
+  diary: DiaryDetailDto | null;
+  events: EventResponseDto[];
 }
 
+// 일정 생성 요청 (EventRequestDto)
 export interface EventCreateRequest {
   title: string;
-  description?: string;
   date: string; // YYYY-MM-DD
-  startTime?: string; // HH:mm
+  startTime: string; // HH:mm (required)
+  description?: string;
 }
 
 // 타임아웃이 있는 fetch 함수
@@ -75,126 +80,92 @@ const getAuthToken = (): string | null => {
   return localStorage.getItem('token');
 };
 
+const getAuthHeaders = (): Record<string, string> => {
+  const token = getAuthToken();
+  if (!token) {
+    throw new Error('인증 토큰이 없습니다. 로그인해주세요.');
+  }
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+};
+
 export const calendarService = {
   // 월별 달력 데이터 조회
   async getMonthCalendar(year: number, month: number, scrapedOnly: boolean = false): Promise<CalendarResponseDto> {
-    try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('No authentication token found. Please log in.');
+    const url = scrapedOnly
+      ? `${API_BASE_URL}/calendar/${year}/${month}?scrapedOnly=true`
+      : `${API_BASE_URL}/calendar/${year}/${month}`;
+
+    const response = await fetchWithTimeout(url, {
+      method: 'GET',
+      headers: getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
       }
-
-      const url = scrapedOnly
-        ? `${API_BASE_URL}/calendar/${year}/${month}?scrapedOnly=true`
-        : `${API_BASE_URL}/calendar/${year}/${month}`;
-
-      const response = await fetchWithTimeout(url, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          throw new Error('Authentication failed. Please log in again.');
-        }
-        throw new Error(`Failed to fetch calendar: ${response.status} ${response.statusText}`);
-      }
-
-      return await response.json();
-    } catch (error) {
-      console.error('Calendar API error:', error);
-      throw new Error(`Failed to fetch calendar: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(`캘린더 조회 실패: ${response.status} ${response.statusText}`);
     }
+
+    return response.json();
   },
 
   // 특정 날짜 상세 정보 조회
   async getDateDetail(date: string): Promise<DateDetailResponseDto> {
-    try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('No authentication token found. Please log in.');
+    const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/date/${date}`, {
+      method: 'GET',
+      headers: getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
       }
-
-      const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/date/${date}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          throw new Error('Authentication failed. Please log in again.');
-        }
-        throw new Error(`Failed to fetch date detail: ${response.status} ${response.statusText}`);
-      }
-
-      return await response.json();
-    } catch (error) {
-      console.error('Date detail API error:', error);
-      throw new Error(`Failed to fetch date detail: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(`날짜 상세 조회 실패: ${response.status} ${response.statusText}`);
     }
+
+    return response.json();
   },
 
   // 일정 등록
-  async createEvent(request: EventCreateRequest): Promise<EventDto> {
-    try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('No authentication token found. Please log in.');
+  async createEvent(request: EventCreateRequest): Promise<EventResponseDto> {
+    const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/events`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
       }
-
-      const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/events`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        body: JSON.stringify(request),
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          throw new Error('Authentication failed. Please log in again.');
-        }
-        throw new Error(`Failed to create event: ${response.status} ${response.statusText}`);
+      if (response.status === 400) {
+        throw new Error('입력값을 확인해주세요. 제목, 날짜, 시작 시간은 필수입니다.');
       }
-
-      return await response.json();
-    } catch (error) {
-      console.error('Create event API error:', error);
-      throw new Error(`Failed to create event: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      throw new Error(`일정 등록 실패: ${response.status} ${response.statusText}`);
     }
+
+    return response.json();
   },
 
   // 일정 삭제
   async deleteEvent(eventId: string): Promise<void> {
-    try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('No authentication token found. Please log in.');
-      }
+    const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/events/${eventId}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    });
 
-      const response = await fetchWithTimeout(`${API_BASE_URL}/calendar/events/${eventId}`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          throw new Error('Authentication failed. Please log in again.');
-        }
-        throw new Error(`Failed to delete event: ${response.status} ${response.statusText}`);
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('인증에 실패했습니다. 다시 로그인해주세요.');
       }
-    } catch (error) {
-      console.error('Delete event API error:', error);
-      throw new Error(`Failed to delete event: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      if (response.status === 404) {
+        throw new Error('해당 일정을 찾을 수 없습니다.');
+      }
+      throw new Error(`일정 삭제 실패: ${response.status} ${response.statusText}`);
     }
   },
 };


### PR DESCRIPTION


  calendarService.ts - 5개 필드 수정

```  ┌─────────────────────────────────────────────────┬────────────────────────────────────────────┐
  │                 Before (프론트)                 │            After (백엔드 일치)             │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ CalendarResponseDto.days                        │ CalendarResponseDto.dates                  │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ DateDetailResponseDto.userEvents / googleEvents │ DateDetailResponseDto.events (단일 리스트) │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ EventDto.id                                     │ EventResponseDto.eventId                   │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ EventDto에 eventType 있음, createdAt 없음       │ eventType 제거, createdAt 추가             │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ DiaryInfoDto에 scraped 없음                     │ DiaryDetailDto.scraped 추가                │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ EventCreateRequest.startTime? (optional)        │ startTime (required)                       │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ 에러 처리: getAuthHeaders로 통합                │ 400/404 별도 에러 메시지 추가              │
  └─────────────────────────────────────────────────┴────────────────────────────────────────────┘
```
  diaryService.ts - 2개 수정 + 1개 추가

```  ┌───────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────┐
  │                   변경                    │                                  내용                                  │
  ├───────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ toggleBookmark(diaryId, currentState)     │ toggleBookmark(diaryId) - body 제거, BackendDiaryResponse 반환         │
  ├───────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ 에러 처리                                 │ getAuthHeaders로 통합, 401/404 별도 처리                               │
  ├───────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ NEW saveFeedback(diaryId, selectedOption) │ POST /aidiary/diary/{diaryId}/feedback 호출, FeedbackSaveResponse 반환 │
  └───────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘
```
  diary-preview.tsx - 호출부 수정

  - toggleBookmark 호출에서 두 번째 인자 제거, 서버 응답(updated.scraped)으로 상태 확정, 에러 시 toast 표시

  diary-write.tsx - feedback API 연동

  - confirmFeedback에서 diaryService.saveFeedback(diaryId, selectedFeedback) 호출
  - diaryId는 query param에서 읽도록 구현 (AI 일기 생성 플로우에서 전달 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diary feedback is now persisted to the server when confirmed.

* **Bug Fixes**
  * Bookmark toggling now confirms changes with the server and restores the original state on failure.
  * Improved error handling with informative error notifications displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->